### PR TITLE
Fix bizarro references and heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just this:
 | `network_chat.trx` | Example of networked messaging |
 | `grammar.md` | Formal syntax specification |
 | `guide.md` | Human-readable intro & tutorial |
-| `bizzaro.md` | Speculative syntax — symbolic side-channel |
+| `bizarro.md` | Speculative syntax — symbolic side-channel |
 
 ## ✦ Quick Start
 

--- a/docs/bizarro.md
+++ b/docs/bizarro.md
@@ -1,4 +1,4 @@
-# Bizzaro Fragments (`bizzaro.md`)
+# Bizarro Fragments (`bizarro.md`)
 
 **Author**: Markus  
 **License**: MIT  
@@ -6,13 +6,13 @@
 
 ---
 
-## ✦ What Are Bizzaro Fragments?
+## ✦ What Are Bizarro Fragments?
 
 Trexxak is built on **triadic structure** — each expression requires a start, a body, and a closure.  
 But in the early days, not everything fit.  
 Some fragments refused to conform — or pointed sideways, inward, or backward through meaning.
 
-We call these the **bizzaro particles**. They are:
+We call these the **bizarro particles**. They are:
 
 - **Structurally legal** — the parser could recognize them
 - **Logically unstable** — they don’t fulfill full triadic expectations
@@ -110,7 +110,7 @@ They show us the space around Trexxak. The negative form of its truth.
 
 ## ✦ Who Should Care?
 
-- **Parser hackers** — you might implement bizzaro mode
+ - **Parser hackers** — you might implement bizarro mode
 - **Symbolic linguists** — you’ll find inversion patterns here
 - **AI meta-modelers** — alternate parsing behaviors could use these as attention weights
 - **Artists and poets** — you’ll feel the emotional texture of syntax in decay
@@ -119,7 +119,7 @@ They show us the space around Trexxak. The negative form of its truth.
 
 ## ✦ Experimental Usage
 
-Although non-canonical, bizzaro fragments can be used for creative experiments or diagnostics. A few ideas:
+Although non-canonical, bizarro fragments can be used for creative experiments or diagnostics. A few ideas:
 
 ```trexxak
 |_               # unfinished thought

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -179,7 +179,7 @@ You shape thought.
 - [`rules_current.trx`](rules_current.trx): Canonical grammar rules
 - [`grammar.md`](grammar.md): Formal syntax specification
 - [`guide.md`](guide.md): Human-readable intro
-- [`bizzaro.md`](bizzaro.md): Speculative symbolic anomalies
+- [`bizarro.md`](bizarro.md): Speculative symbolic anomalies
 
 ---
 

--- a/suggestions.md
+++ b/suggestions.md
@@ -21,7 +21,7 @@ The examples demonstrate how expressions are built from a triadic structure usin
 3. **Expand real‑world examples.** The provided examples are helpful. Additional
    scenarios—such as networked messaging or interactive sessions—would showcase
    the symbolic approach in varied contexts.
-4. **Document bizzaro usage patterns.** `bizarro.md` lists non‑canonical forms but
+4. **Document bizarro usage patterns.** `bizarro.md` lists non‑canonical forms but
    does not show when you might intentionally use them. Small snippets exploring
    possible creative or experimental uses could inspire advanced users.
 5. **Add quick‑start instructions in the README.** A new user could benefit from a


### PR DESCRIPTION
## Summary
- normalize references to docs/bizarro.md
- fix heading wording inside docs/bizarro.md

## Testing
- `python -m py_compile interpreter_example.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6bc81a8083269ea909d4d3170d13